### PR TITLE
fix: Architecture review — PHI redaction, version consistency, shell injection, shared report builder

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -62,14 +62,14 @@ runs:
         
         # Run scan and capture output
         hipaalint scan "$SCAN_PATH" \
-          --framework ${{ inputs.framework }} \
-          --sensitivity ${{ inputs.sensitivity }} \
+          --framework "${{ inputs.framework }}" \
+          --sensitivity "${{ inputs.sensitivity }}" \
           --json > /tmp/scan-results.json 2>&1 || true
         
         # Run score
         SCORE_JSON=$(hipaalint score "$SCAN_PATH" \
-          --framework ${{ inputs.framework }} \
-          --sensitivity ${{ inputs.sensitivity }} \
+          --framework "${{ inputs.framework }}" \
+          --sensitivity "${{ inputs.sensitivity }}" \
           --json 2>/dev/null)
         
         SCORE=$(echo "$SCORE_JSON" | jq -r '.overallScore')
@@ -82,9 +82,9 @@ runs:
         
         # Generate report
         hipaalint report "$SCAN_PATH" \
-          --framework ${{ inputs.framework }} \
-          --sensitivity ${{ inputs.sensitivity }} \
-          --format ${{ inputs.format }} \
+          --framework "${{ inputs.framework }}" \
+          --sensitivity "${{ inputs.sensitivity }}" \
+          --format "${{ inputs.format }}" \
           --output "${{ github.workspace }}" 2>/dev/null || true
         
         # Find report file
@@ -110,8 +110,8 @@ runs:
       if: inputs.threshold != '0'
       shell: bash
       run: |
-        SCORE=${{ steps.scan.outputs.score }}
-        THRESHOLD=${{ inputs.threshold }}
+        SCORE="${{ steps.scan.outputs.score }}"
+        THRESHOLD="${{ inputs.threshold }}"
         if (( $(echo "$SCORE < $THRESHOLD" | bc -l) )); then
           echo "❌ HipaaLint score ($SCORE) is below threshold ($THRESHOLD)"
           exit 1

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,9 +8,9 @@ import { AutoFixer, getFixableRuleIds } from '../engine/auto-fixer.js';
 import { generateJsonReport, generateSarifReport } from '../reports/json-report.js';
 import { generatePdfReport } from '../reports/pdf-report.js';
 import { PHIDetector } from '../engine/phi-detector.js';
-import type { ComplianceReport } from '../engine/types.js';
-import { randomUUID } from 'crypto';
-import { resolve, basename, relative, sep } from 'path';
+import { buildReport } from '../reports/report-builder.js';
+import { VERSION } from '../version.js';
+import { resolve, relative, sep } from 'path';
 import { readFileSync } from 'fs';
 import {
   SecurityError,
@@ -22,8 +22,6 @@ import {
   PHIOptionsSchema,
   RulesOptionsSchema,
 } from '../security/index.js';
-
-const VERSION = '0.1.0';
 
 // ──────────────────────────────────────────────────
 // Graceful shutdown — close resources on interrupt
@@ -341,40 +339,7 @@ program
       const calculator = new ScoreCalculator();
       const score = calculator.calculateScore(result, validated.framework, sensitivity);
 
-      const report: ComplianceReport = {
-        id: randomUUID(),
-        version: VERSION,
-        projectName: basename(targetPath),
-        projectPath: targetPath,
-        generatedAt: new Date().toISOString(),
-        score,
-        findings: result.findings,
-        summary: {
-          totalFindings: result.findings.length,
-          bySeverity: {
-            critical: result.findings.filter((f) => f.severity === 'critical').length,
-            high: result.findings.filter((f) => f.severity === 'high').length,
-            medium: result.findings.filter((f) => f.severity === 'medium').length,
-            low: result.findings.filter((f) => f.severity === 'low').length,
-            info: result.findings.filter((f) => f.severity === 'info').length,
-          },
-          byCategory: {
-            phi_protection: result.findings.filter((f) => f.category === 'phi_protection').length,
-            encryption: result.findings.filter((f) => f.category === 'encryption').length,
-            access_control: result.findings.filter((f) => f.category === 'access_control').length,
-            audit_logging: result.findings.filter((f) => f.category === 'audit_logging').length,
-            infrastructure: result.findings.filter((f) => f.category === 'infrastructure').length,
-            ai_governance: result.findings.filter((f) => f.category === 'ai_governance').length,
-          },
-        },
-        recommendations: [],
-        metadata: {
-          hipaalintVersion: VERSION,
-          rulesVersion: '2025.1',
-          frameworksEvaluated: [validated.framework],
-          sensitivity,
-        },
-      };
+      const report = buildReport(result, score, targetPath, validated.framework, sensitivity);
 
       let reportPath: string;
       switch (validated.format) {

--- a/src/engine/auto-fixer.ts
+++ b/src/engine/auto-fixer.ts
@@ -225,9 +225,6 @@ export class AutoFixer {
    * Excludes localhost, 127.0.0.1, and 0.0.0.0 (safe for local dev).
    */
   private fixUnencryptedHttp(line: string): { fixedLine: string; description: string } | null {
-    const regex = /http:\/\/(?!localhost|127\.0\.0\.1|0\.0\.0\.0)/g;
-    if (!regex.test(line)) return null;
-
     const fixedLine = line.replace(/http:\/\/(?!localhost|127\.0\.0\.1|0\.0\.0\.0)/g, 'https://');
     if (fixedLine === line) return null;
     return {
@@ -241,9 +238,6 @@ export class AutoFixer {
    * Handles TLSv1_0, TLSv1_1, SSLv3, ssl3, tls1_0, tls1_1.
    */
   private fixWeakTLS(line: string): { fixedLine: string; description: string } | null {
-    const weakPattern = /\b(TLSv1_0|TLSv1_1|SSLv3|ssl3|tls1_0|tls1_1)\b/g;
-    if (!weakPattern.test(line)) return null;
-
     const fixedLine = line.replace(/\b(TLSv1_0|TLSv1_1|SSLv3|ssl3|tls1_0|tls1_1)\b/g, (match) => {
       // Preserve casing convention
       if (/^[A-Z]/.test(match)) return 'TLSv1_2';

--- a/src/engine/rule-evaluator.ts
+++ b/src/engine/rule-evaluator.ts
@@ -946,6 +946,14 @@ export class RuleEvaluator {
    */
   private sanitizeCodeSnippet(line: string): string {
     let sanitized = line.trim();
+    // Redact known PHI patterns to prevent leakage in reports
+    sanitized = sanitized.replace(/\b\d{3}-\d{2}-\d{4}\b/g, '[REDACTED-SSN]');
+    sanitized = sanitized.replace(
+      /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+      '[REDACTED-EMAIL]',
+    );
+    sanitized = sanitized.replace(/\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}/g, '[REDACTED-PHONE]');
+    sanitized = sanitized.replace(/\bMRN[-_:# ]?\d{4,12}\b/gi, '[REDACTED-MRN]');
     // Truncate long lines
     if (sanitized.length > 200) {
       sanitized = sanitized.substring(0, 200) + '...';

--- a/src/engine/score-calculator.ts
+++ b/src/engine/score-calculator.ts
@@ -8,6 +8,7 @@ import type {
   SensitivityLevel,
 } from './types.js';
 import { DOMAIN_WEIGHTS, SCORE_BAND_THRESHOLDS, SCORE_CLAMP_RULES } from './types.js';
+import { VERSION } from '../version.js';
 
 // ──────────────────────────────────────────────────
 // Category → Domain mapping
@@ -73,7 +74,7 @@ export class ScoreCalculator {
         rulesEvaluated: scanResult.rulesEvaluated,
         framework,
         sensitivity,
-        engineVersion: '0.1.0',
+        engineVersion: VERSION,
       },
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,11 @@ export {
   generateBadgeMarkdown,
   generateBadgeSvg,
 } from './reports/badge-generator.js';
+export {
+  buildReport,
+  generateRecommendations,
+} from './reports/report-builder.js';
+export { VERSION, RULES_VERSION } from './version.js';
 
 // Security
 export {

--- a/src/mcp-server/index.ts
+++ b/src/mcp-server/index.ts
@@ -8,10 +8,11 @@ import { RuleEvaluator } from '../engine/rule-evaluator.js';
 import { ScoreCalculator } from '../engine/score-calculator.js';
 import { generateJsonReport } from '../reports/json-report.js';
 import { generatePdfReport } from '../reports/pdf-report.js';
-import type { ComplianceFinding, ComplianceReport } from '../engine/types.js';
+import { buildReport } from '../reports/report-builder.js';
+import { VERSION } from '../version.js';
+import type { ComplianceFinding } from '../engine/types.js';
 import { countFindings } from '../engine/finding-counter.js';
-import { randomUUID } from 'crypto';
-import { basename, relative, sep } from 'path';
+import { relative, sep } from 'path';
 import {
   SecurityError,
   validateScanPath,
@@ -30,7 +31,7 @@ import {
 const server = new Server(
   {
     name: 'hipaalint-ai',
-    version: '0.1.0',
+    version: VERSION,
   },
   {
     capabilities: {
@@ -373,28 +374,7 @@ async function handleReport(args: Record<string, unknown>) {
     const calculator = new ScoreCalculator();
     const score = calculator.calculateScore(result, validated.framework, validated.sensitivity);
 
-    const reportCounts = countFindings(result.findings);
-    const report: ComplianceReport = {
-      id: randomUUID(),
-      version: '0.1.0',
-      projectName: basename(path),
-      projectPath: path,
-      generatedAt: new Date().toISOString(),
-      score,
-      findings: result.findings,
-      summary: {
-        totalFindings: reportCounts.total,
-        bySeverity: reportCounts.bySeverity,
-        byCategory: reportCounts.byCategory,
-      },
-      recommendations: generateRecommendations(result.findings),
-      metadata: {
-        hipaalintVersion: '0.1.0',
-        rulesVersion: '2025.1',
-        frameworksEvaluated: [validated.framework],
-        sensitivity: validated.sensitivity,
-      },
-    };
+    const report = buildReport(result, score, path, validated.framework, validated.sensitivity);
 
     let reportPath: string;
 
@@ -520,36 +500,7 @@ async function handleRules(args: Record<string, unknown>) {
   }
 }
 
-function generateRecommendations(findings: ComplianceFinding[]) {
-  const recs: ComplianceReport['recommendations'] = [];
-
-  // Group by rule — highest severity first
-  const byRule = new Map<string, ComplianceFinding[]>();
-  for (const f of findings) {
-    const existing = byRule.get(f.ruleId) || [];
-    existing.push(f);
-    byRule.set(f.ruleId, existing);
-  }
-
-  const severityOrder = { critical: 1, high: 2, medium: 3, low: 4, info: 5 };
-  const sorted = [...byRule.entries()].sort((a, b) => {
-    const aMax = Math.min(...a[1].map((f) => severityOrder[f.severity]));
-    const bMax = Math.min(...b[1].map((f) => severityOrder[f.severity]));
-    return aMax - bMax;
-  });
-
-  let priority = 1;
-  for (const [ruleId, ruleFindings] of sorted) {
-    recs.push({
-      priority,
-      description: `Fix ${ruleFindings.length} ${ruleFindings[0]!.severity} finding(s): ${ruleFindings[0]!.title}. ${ruleFindings[0]!.remediation}`,
-      affectedRules: [ruleId],
-    });
-    priority++;
-  }
-
-  return recs;
-}
+// generateRecommendations is now in reports/report-builder.ts
 
 // ──────────────────────────────────────────────────
 // Start Server

--- a/src/reports/report-builder.ts
+++ b/src/reports/report-builder.ts
@@ -1,0 +1,77 @@
+import type { ComplianceFinding, ComplianceReport, SensitivityLevel } from '../engine/types.js';
+import type { ScanResult, ComplianceScore } from '../engine/types.js';
+import { countFindings } from '../engine/finding-counter.js';
+import { VERSION, RULES_VERSION } from '../version.js';
+import { randomUUID } from 'crypto';
+import { basename } from 'path';
+
+/**
+ * Build a ComplianceReport from scan results and score.
+ */
+export function buildReport(
+    scanResult: ScanResult,
+    score: ComplianceScore,
+    projectPath: string,
+    framework: string,
+    sensitivity: SensitivityLevel,
+): ComplianceReport {
+    const counts = countFindings(scanResult.findings);
+
+    return {
+        id: randomUUID(),
+        version: VERSION,
+        projectName: basename(projectPath),
+        projectPath,
+        generatedAt: new Date().toISOString(),
+        score,
+        findings: scanResult.findings,
+        summary: {
+            totalFindings: counts.total,
+            bySeverity: counts.bySeverity,
+            byCategory: counts.byCategory,
+        },
+        recommendations: generateRecommendations(scanResult.findings),
+        metadata: {
+            hipaalintVersion: VERSION,
+            rulesVersion: RULES_VERSION,
+            frameworksEvaluated: [framework],
+            sensitivity,
+        },
+    };
+}
+
+/**
+ * Generate prioritized recommendations from findings.
+ */
+export function generateRecommendations(
+    findings: ComplianceFinding[],
+): ComplianceReport['recommendations'] {
+    const recs: ComplianceReport['recommendations'] = [];
+
+    // Group by rule — highest severity first
+    const byRule = new Map<string, ComplianceFinding[]>();
+    for (const f of findings) {
+        const existing = byRule.get(f.ruleId) || [];
+        existing.push(f);
+        byRule.set(f.ruleId, existing);
+    }
+
+    const severityOrder = { critical: 1, high: 2, medium: 3, low: 4, info: 5 };
+    const sorted = [...byRule.entries()].sort((a, b) => {
+        const aMax = Math.min(...a[1].map((f) => severityOrder[f.severity]));
+        const bMax = Math.min(...b[1].map((f) => severityOrder[f.severity]));
+        return aMax - bMax;
+    });
+
+    let priority = 1;
+    for (const [ruleId, ruleFindings] of sorted) {
+        recs.push({
+            priority,
+            description: `Fix ${ruleFindings.length} ${ruleFindings[0]!.severity} finding(s): ${ruleFindings[0]!.title}. ${ruleFindings[0]!.remediation}`,
+            affectedRules: [ruleId],
+        });
+        priority++;
+    }
+
+    return recs;
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,3 @@
+// Single source of truth for version — matches package.json
+export const VERSION = '1.0.0';
+export const RULES_VERSION = '2025.1';


### PR DESCRIPTION
## Summary

Fresh architecture review of the updated codebase (7,230 additions across 74 files). Identified and fixed 6 issues.

## Changes

### 1. PHI Redaction in Code Snippets
`sanitizeCodeSnippet` in `rule-evaluator.ts` now redacts SSN, email, phone, and MRN patterns before including them in JSON/SARIF/PDF reports. Previously it only truncated long lines.

### 2. CLI Report Empty Recommendations
The CLI `report` command was hardcoding `recommendations: []`. Now uses shared `buildReport()` which calls `generateRecommendations()`.

### 3. Auto-Fixer Stateful Regex Bug
`fixUnencryptedHttp()` and `fixWeakTLS()` both called `.test()` on a global regex (advancing `lastIndex`), then `.replace()` — which could miss matches. Simplified to just `.replace()` + equality check.

### 4. Version Consistency
Created `src/version.ts` as single source of truth. Replaced hardcoded `'0.1.0'` in CLI, MCP server, and score-calculator with the shared `VERSION` constant (`1.0.0`, matching `package.json`).

### 5. GitHub Action Shell Injection
Quoted all `${{ inputs.* }}` and `${{ steps.*.outputs.* }}` references in `action.yml` `run:` blocks to prevent shell injection via crafted PR inputs.

### 6. Shared Report Builder
Extracted `generateRecommendations()` from MCP server into `src/reports/report-builder.ts`. Both CLI and MCP now import from this shared module, eliminating ~90 lines of duplication.

## New Files
- `src/version.ts` — Central `VERSION` and `RULES_VERSION` constants
- `src/reports/report-builder.ts` — Shared `buildReport()` and `generateRecommendations()`

## Verification
- ✅ `npm run typecheck` — clean
- ✅ `npm run lint` — 0 warnings
- ✅ `npm run test` — 276/276 passed
- ✅ `npm run build` — success